### PR TITLE
Remove modal overlay and refactor JS to use `.closest(...)`

### DIFF
--- a/statix.lang/trans/generation/docs/gen-docs-pages.str
+++ b/statix.lang/trans/generation/docs/gen-docs-pages.str
@@ -131,13 +131,11 @@ rules // Actions
         ${
           </code></pre></td>{div-end}
           
-          <div id="modal">
-            <div id="modal-content">
-              <span id="modal-close">&times;</span>
-              <h2 id="modal-h2"></h2>
-              <p  id="modal-p"></p>
-              <ul id="modal-ul"></ul>
-            </div>
+          <div id="modal-content">
+            <span id="modal-close">&times;</span>
+            <h2 id="modal-h2"></h2>
+            <p  id="modal-p"></p>
+            <ul id="modal-ul"></ul>
           </div>
           }, outs)
     ; <fclose> ins

--- a/statix.lang/trans/generation/docs/modal.css
+++ b/statix.lang/trans/generation/docs/modal.css
@@ -1,14 +1,16 @@
 /* Modal Content/Box */
 #modal-content {
+  display: none;
+  position: fixed;
+  left: 50%;
+  top: 5rem;
+  z-index: 5; /* Header of the page has z-index: 4 */
+  transform: translate(-50%, 0);
   background-color: var(--md-code-bg-color);
   padding: 20px;
   border: 1px solid var(--md-code-fg-color);
   width: fit-content;
   max-width: 30rem;
-  display: none;
-  position: absolute;
-  left: 0;
-  top: 0;
 }
 
 #modal-content h2 {

--- a/statix.lang/trans/generation/docs/modal.css
+++ b/statix.lang/trans/generation/docs/modal.css
@@ -1,25 +1,14 @@
-/* The Modal (background) */
-#modal {
-  display: none;
-  position: fixed;
-  z-index: 1;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-  background-color: rgb(0,0,0); /* Fallback color */
-  background-color: rgba(0,0,0,0.4); /* Black with opacity */
-}
-
 /* Modal Content/Box */
 #modal-content {
   background-color: var(--md-code-bg-color);
-  margin: 5rem auto; /* Fixed distance from the top and centered */
   padding: 20px;
   border: 1px solid var(--md-code-fg-color);
   width: fit-content;
   max-width: 30rem;
+  display: none;
+  position: absolute;
+  left: 0;
+  top: 0;
 }
 
 #modal-content h2 {

--- a/statix.lang/trans/generation/docs/modal.js
+++ b/statix.lang/trans/generation/docs/modal.js
@@ -74,20 +74,8 @@ function btnClick(event) {
   for (const anchor of anchors) {
     anchor.addEventListener("click", closeModal);
   }
-  // Move the modal below the button
-  const nodeRect = node.getBoundingClientRect();
-  const marginLeft = nodeRect.left + window.scrollX;
-  const marginTop = nodeRect.bottom + window.scrollY;
-  modal.style.margin = `${marginTop + "px"} 0 0 ${marginLeft + "px"}`;
-  const pageLengthBefore = document.documentElement.scrollHeight;
   // Make the modal contents visible
   modal.style.display = "block";
-  // If the modal is outside the page, show it above the button
-  // Unfortunately, there is no reliable way to know this before changing the display
-  if (document.documentElement.scrollHeight > pageLengthBefore) {
-    const newMarginTop = marginTop - nodeRect.height - modal.getBoundingClientRect().height;
-    modal.style.margin = `${newMarginTop + "px"} 0 0 ${marginLeft + "px"}`;
-  }
 }
 
 for (const btn of btns) {

--- a/statix.lang/trans/generation/docs/modal.js
+++ b/statix.lang/trans/generation/docs/modal.js
@@ -105,7 +105,7 @@ function windowClick(event) {
   // - the click is not aimed at a button that opens the modal and
   // - the click is outside the modal
   if (modal.style.display != "none"
-      && event.target.parentNode.tagName != "BUTTON"
+      && event.target.closest("button.modal-open") != null
       && event.target.closest('#modal-content') == null) {
     closeModal(event);
   }

--- a/statix.lang/trans/generation/docs/modal.js
+++ b/statix.lang/trans/generation/docs/modal.js
@@ -79,8 +79,15 @@ function btnClick(event) {
   const marginLeft = nodeRect.left + window.scrollX;
   const marginTop = nodeRect.bottom + window.scrollY;
   modal.style.margin = `${marginTop + "px"} 0 0 ${marginLeft + "px"}`;
+  const pageLengthBefore = document.documentElement.scrollHeight;
   // Make the modal contents visible
   modal.style.display = "block";
+  // If the modal is outside the page, show it above the button
+  // Unfortunately, there is no reliable way to know this before changing the display
+  if (document.documentElement.scrollHeight > pageLengthBefore) {
+    const newMarginTop = marginTop - nodeRect.height - modal.getBoundingClientRect().height;
+    modal.style.margin = `${newMarginTop + "px"} 0 0 ${marginLeft + "px"}`;
+  }
 }
 
 for (const btn of btns) {

--- a/statix.lang/trans/generation/docs/modal.js
+++ b/statix.lang/trans/generation/docs/modal.js
@@ -6,7 +6,7 @@
 // TODO: Replace by a CSS-only modal (or add a no-js fallback)
 
 // Get the modal elements
-const modal = document.getElementById("modal");
+const modal = document.getElementById("modal-content");
 const h2    = document.getElementById("modal-h2");
 const p     = document.getElementById("modal-p");
 const ul    = document.getElementById("modal-ul");
@@ -46,10 +46,8 @@ function urlItem(url) {
 
 // When the user clicks in any button, open the modal 
 function btnClick(event) {
-  let node = event.target;
-  while (node && node.tagName != "BUTTON") {
-    node = node.parentNode;
-  }
+  const node = event.target.closest("button.modal-open");
+
   // Copy the button contents to a code element in the modal heading
   h2.replaceChildren();
   if (node.hasChildNodes()) {
@@ -76,6 +74,11 @@ function btnClick(event) {
   for (const anchor of anchors) {
     anchor.addEventListener("click", closeModal);
   }
+  // Move the modal below the button
+  const nodeRect = node.getBoundingClientRect();
+  const marginLeft = nodeRect.left + window.scrollX;
+  const marginTop = nodeRect.bottom + window.scrollY;
+  modal.style.margin = `${marginTop + "px"} 0 0 ${marginLeft + "px"}`;
   // Make the modal contents visible
   modal.style.display = "block";
 }
@@ -102,7 +105,13 @@ if (close) {
 // When the user clicks anywhere outside the modal, close it
 
 function windowClick(event) {
-  if (event.target == modal) {
+  // Only close the modal when:
+  // - it is currently open and
+  // - the click is not aimed at a button that opens the modal and
+  // - the click is outside the modal
+  if (modal.style.display != "none"
+      && event.target.parentNode.tagName != "BUTTON"
+      && event.target.closest('#modal-content') == null) {
     closeModal(event);
   }
 }


### PR DESCRIPTION
This PR removes the semi-transparent overlay for the modal and changes its CSS to maintain the same behaviour.

Additionally, this PR refactors DOM Node finding logic to use the [closest(...) function](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) where applicable. 

----- PREVIOUS DESCRIPTION -----
This PR changes the positioning of the modal in the generated hyperlinked twin. Currently it shows centrally on the page with an overlay on the rest. This PR moves the modal below the clicked reference/definition. When there is no space below the node, it will position above it instead.

Using `position: absolute` and changing the `margin`s of the modal, it is positioned based on the information from the clicked node. Any click outside the modal will close it.